### PR TITLE
Remove GA ID and disable GA by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ A Progressive Web App for Apple Music built with Angular, Angular Material, and 
 ## Development server
 
 Run `ng serve --aot` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+
+### Google Analytic tokens
+
+Google Analytics is disabled by default but easily uncommented in the source and enabled. You can easily find the snippets by searching the repo for "gtag" and changing as appropriate. Below is a simple example on how to replace the token using Bash.
+
+```Bash
+cd $projectFolder/src/
+gaID="Your GA token here"
+sed -i "s/\$id/${gaID}/" ./app/app.component.ts
+sed -i "s/\$id/${gaID}/" index.html
+```

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,7 +35,7 @@ export class AppComponent {
         this.opened = false;
       }
       if ( event instanceof NavigationEnd ) {
-        (<any>window).gtag('config', 'UA-118675595-2', {'page_path': event.urlAfterRedirects});
+       // (<any>window).gtag('config', '$id', {'page_path': event.urlAfterRedirects});
       }
     });
   }

--- a/src/index.html
+++ b/src/index.html
@@ -27,12 +27,12 @@
   <meta name="theme-color" content="#1e3264">
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-118675595-2"></script>
+  <!--  <script async src="https://www.googletagmanager.com/gtag/js?id=$id"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-  </script>
+  </script> -->
 
 </head>
 <body class="mat-app-background">


### PR DESCRIPTION
Disables GA by default in repo. Updates the readme on how to easily reenable.